### PR TITLE
Lightened the background color.

### DIFF
--- a/ujelly-theme.el
+++ b/ujelly-theme.el
@@ -9,7 +9,7 @@
 
 (let ((class '((class color) (min-colors 89)))
       (ujelly-fg "#ffffff")
-      (ujelly-bg "#000000")
+      (ujelly-bg "#141414")
       (ujelly-blue-0 "#8fbfdc")
       (ujelly-green-0 "#99ad6a")
       (ujelly-green-1 "#447799")


### PR DESCRIPTION
The original jellybeans.vim color scheme does not use a black
background, but a dark grey.  Looking at the code, the RGB value is
151515, so I've changed ujelly's background color to 141414.

References:
https://github.com/nanotech/jellybeans.vim/blob/master/colors/jellybeans.vim#L301
http://nanotech.nanotechcorp.net/downloads/jellybeans-preview.png
