### PR TITLE
Add some faces for structured-haskell-mode

### DIFF
--- a/ujelly-theme.el
+++ b/ujelly-theme.el
@@ -129,6 +129,8 @@
        `(org-special-keyword ((,class (:foreground ,ujelly-purple-0))))
        `(org-todo ((,class (:foreground ,ujelly-yellow-0))))
        `(region ((,class (:background ,ujelly-purple-1))))
+       `(shm-current-face ((,class (:background ,ujelly-grey-4))))
+       `(shm-quarantine-face ((,class (:background ,ujelly-red-1))))
        `(smerge-markers ((,class (:foreground ,ujelly-yellow-0 :background ,ujelly-grey-2))))
        `(smerge-refined-change ((,class (:foreground ,ujelly-green-0))))
        `(trailing-whitespace ((,class (:background ,ujelly-red-1))))


### PR DESCRIPTION
This change adds support for block highlighting using [structured-haskell-mode](https://github.com/chrisdone/structured-haskell-mode).

![screenshot 2014-12-22 14 25 06](https://cloud.githubusercontent.com/assets/111265/5524951/ff8cde2a-89e6-11e4-9948-7f2a3b6a9c6b.png)
